### PR TITLE
Physic: QrackOpenRelativity

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ An intuitive Unity3d finite state machine (FSM). Designed with an emphasis on us
 
 - [BulletSharpUnity3d](https://github.com/Phong13/BulletSharpUnity3d) - A fork of the BulletSharp project to make the Bullet Physics Engine usable from C# code in Unity3d.
 - [Graphics-Raycast](https://github.com/Jonny10/Graphics-Raycast) - GPU-based raycaster for Unity.
+- [QrackOpenRelativity](https://github.com/vm6502q/OpenRelativity) - A fork of the (MIT Game Lab) OpenRelativity project, by the developers of the [`unitaryfund/qrack`](https://github.com/unitaryfund/qrack) quantum computer simulation library, to add qubit simulation in and with relativistic gravity backgrounds, to generalize built-in Unity PhysX to quantum relativity (including shaders).
 
 ### Plugins
 


### PR DESCRIPTION
Thanks for maintaining an awesome list! Feel free to suggest a different wording, but this is an MIT-License fork of OpenRelativity (by the MIT Game Lab) that I've improved and maintained for a number of years. 

I wrote the [Qrack](https://github.com/unitaryfund/qrack)/[PyQrack](https://github.com/unitaryfund/pyqrack) quantum computer simulator, which now has well over 1,000,000 downloads. I actually started the "QrackOpenRelativity" fork a couple of years before I started writing Qrack, but the two projects are now fully integrated as a "modern physics" module that basically "plugs in" relativity and quantum mechanics to native Unity PhysX. Among other assets, this module effectively includes a "Standard Relativity Shader," for relativistic optics (and Lorentz transforms).